### PR TITLE
Update to latest android mobile sdk dependencies

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,10 +35,10 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.adobe.marketing.mobile.flutter.flutter_aepsdk_example"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -56,6 +56,6 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 }

--- a/example/android/app/src/main/java/com/adobe/marketing/mobile/flutter/flutter_aepsdk_example/MyApplication.java
+++ b/example/android/app/src/main/java/com/adobe/marketing/mobile/flutter/flutter_aepsdk_example/MyApplication.java
@@ -13,10 +13,19 @@ package com.adobe.marketing.mobile.flutter.flutter_aepsdk_example;
 
 import android.app.Activity;
 import android.os.Bundle;
-import android.util.Log;
 
-import com.adobe.marketing.mobile.*;
+import com.adobe.marketing.mobile.Assurance;
+import com.adobe.marketing.mobile.Edge;
+import com.adobe.marketing.mobile.Extension;
+import com.adobe.marketing.mobile.Lifecycle;
+import com.adobe.marketing.mobile.LoggingMode;
+import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.Signal;
+import com.adobe.marketing.mobile.WrapperType;
 import com.adobe.marketing.mobile.edge.consent.Consent;
+
+import java.util.Arrays;
+import java.util.List;
 
 import io.flutter.app.FlutterApplication;
 
@@ -32,24 +41,17 @@ public class MyApplication extends FlutterApplication {
         MobileCore.setApplication(this);
         MobileCore.setLogLevel(LoggingMode.VERBOSE);
         MobileCore.setWrapperType(WrapperType.FLUTTER);
-        
-        try {
-            com.adobe.marketing.mobile.edge.identity.Identity.registerExtension();
-            com.adobe.marketing.mobile.Identity.registerExtension();
-            Lifecycle.registerExtension();
-            Signal.registerExtension();
-            Edge.registerExtension();
-            Assurance.registerExtension();
-            Consent.registerExtension();
-            MobileCore.start(new AdobeCallback () {
-                @Override
-                public void call(Object o) {
-                    MobileCore.configureWithAppID(ENVIRONMENT_FILE_ID);
-                }
-            });
-        } catch (InvalidInitException e) {
-            Log.e("MyApplication", String.format("Error while registering extensions %s", e.getLocalizedMessage()));
-        }
+
+        List<Class<? extends Extension>> extensions = Arrays.asList(
+                Lifecycle.EXTENSION,
+                Signal.EXTENSION,
+                Edge.EXTENSION,
+                Assurance.EXTENSION,
+                Consent.EXTENSION,
+                com.adobe.marketing.mobile.edge.identity.Identity.EXTENSION,
+                com.adobe.marketing.mobile.Identity.EXTENSION
+        );
+        MobileCore.registerExtensions(extensions, o -> MobileCore.configureWithAppID(ENVIRONMENT_FILE_ID));
 
         registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
             @Override

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Mar 15 14:27:20 MDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,131 +5,143 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: a937da4c006989739ceb4d10e3bd6cce64ca85d0fe287fc5b2b9f6ee757dcee6
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
   flutter_aepassurance:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
-      name: flutter_aepassurance
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
+      path: "../plugins/flutter_aepassurance"
+      relative: true
+    source: path
+    version: "2.0.0"
   flutter_aepcore:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
-      name: flutter_aepcore
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
+      path: "../plugins/flutter_aepcore"
+      relative: true
+    source: path
+    version: "2.0.0"
   flutter_aepedge:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
-      name: flutter_aepedge
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
+      path: "../plugins/flutter_aepedge"
+      relative: true
+    source: path
+    version: "2.0.0"
   flutter_aepedgeconsent:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
-      name: flutter_aepedgeconsent
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
+      path: "../plugins/flutter_aepedgeconsent"
+      relative: true
+    source: path
+    version: "2.0.0"
   flutter_aepedgeidentity:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
-      name: flutter_aepedgeidentity
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
+      path: "../plugins/flutter_aepedgeidentity"
+      relative: true
+    source: path
+    version: "2.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -139,58 +151,57 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,19 +14,35 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
 
+  flutter_aepcore: ">= 2.0.0 <3.0.0"
+
+  flutter_aepassurance: ">= 2.0.0 <3.0.0"
+
+  flutter_aepedge: ">= 2.0.0 <3.0.0"
+
+  flutter_aepedgeconsent: ">= 2.0.0 <3.0.0"
+
+  flutter_aepedgeidentity: ">= 2.0.0 <3.0.0"  
+
+dependency_overrides:
+  flutter_aepcore:
+    path: ../plugins/flutter_aepcore
+
+  flutter_aepassurance:
+    path: ../plugins/flutter_aepassurance
+
+  flutter_aepedge:
+    path: ../plugins/flutter_aepedge
+
+  flutter_aepedgeconsent:
+    path: ../plugins/flutter_aepedgeconsent
+
+  flutter_aepedgeidentity:
+    path: ../plugins/flutter_aepedgeidentity
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  flutter_aepcore: ">= 1.0.0 <2.0.0"
-
-  flutter_aepassurance: ">= 1.0.0 <2.0.0"
-  
-  flutter_aepedge: ">= 1.0.0 <2.0.0"
-
-  flutter_aepedgeconsent: ">= 1.0.0 <2.0.0"
-
-  flutter_aepedgeidentity: ">= 1.0.0 <2.0.0"  
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/plugins/flutter_aepassurance/android/build.gradle
+++ b/plugins/flutter_aepassurance/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.adobe.marketing.mobile.flutter.flutter_aepassurance'
-version '1.0'
+version '2.0'
 
 buildscript {
     repositories {
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.1'
     }
 }
 
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -34,7 +34,6 @@ android {
 }
 
 dependencies {
-    api 'com.adobe.marketing.mobile:assurance:1+'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    api 'com.adobe.marketing.mobile:assurance:2.+'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 }

--- a/plugins/flutter_aepassurance/android/build.gradle
+++ b/plugins/flutter_aepassurance/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 
@@ -22,10 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdk 33
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     lintOptions {

--- a/plugins/flutter_aepassurance/android/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/flutter_aepassurance/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/plugins/flutter_aepassurance/pubspec.yaml
+++ b/plugins/flutter_aepassurance/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_aepassurance
 
 description: Official Adobe Experience Platform support for Flutter apps. Assurance is a new, innovative product from Adobe to help you easily validate SDK implementations.
-version: 1.0.0
+version: 2.0.0
 
 homepage: https://aep-sdks.gitbook.io/docs/
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepassurance
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 1.0.0 <2.0.0"
+  flutter_aepcore: ">= 2.0.0 <3.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepcore/android/build.gradle
+++ b/plugins/flutter_aepcore/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 19

--- a/plugins/flutter_aepcore/android/build.gradle
+++ b/plugins/flutter_aepcore/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.adobe.marketing.mobile.flutter.flutter_aepcore'
-version '1.0'
+version '2.0'
 
 buildscript {
     repositories {
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.1'
     }
 }
 
@@ -22,11 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 33
 
     defaultConfig {
-        minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        minSdkVersion 19
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -34,5 +34,8 @@ android {
 }
 
 dependencies {
-    api 'com.adobe.marketing.mobile:sdk-core:1.+'
+    api 'com.adobe.marketing.mobile:core:2.+'
+    api 'com.adobe.marketing.mobile:identity:2.+'
+    api 'com.adobe.marketing.mobile:lifecycle:2.+'
+    api 'com.adobe.marketing.mobile:signal:2.+'
 }

--- a/plugins/flutter_aepcore/android/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/flutter_aepcore/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/plugins/flutter_aepcore/pubspec.yaml
+++ b/plugins/flutter_aepcore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aepcore
 description: Official Adobe Experience Platform support for Flutter apps. The Mobile Core represents the core Adobe Experience Platform SDK that is required for every app implementation.
-version: 1.0.0
+version: 2.0.0
 homepage: https://aep-sdks.gitbook.io/docs/
 repository: https://github.com/adobe/aepsdk-flutter/tree/main/plugins/flutter_aepcore
 

--- a/plugins/flutter_aepedge/android/build.gradle
+++ b/plugins/flutter_aepedge/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 19

--- a/plugins/flutter_aepedge/android/build.gradle
+++ b/plugins/flutter_aepedge/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.adobe.marketing.mobile.flutter.flutter_aepedge'
-version '1.0'
+version '2.0'
 
 buildscript {
     repositories {
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.1'
     }
 }
 
@@ -22,11 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 19
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.adobe.marketing.mobile:edge:1+'
+    api 'com.adobe.marketing.mobile:edge:2.+'
 }

--- a/plugins/flutter_aepedge/android/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/flutter_aepedge/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/plugins/flutter_aepedge/pubspec.yaml
+++ b/plugins/flutter_aepedge/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_aepedge
 
 description: Official Adobe Experience Platform support for Flutter apps. The Experience Platform Edge extension enables sending data to the Adobe Experience Edge from a mobile device.
-version: 1.0.0
+version: 2.0.0
 homepage: https://aep-sdks.gitbook.io/docs/
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepedge
 
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 1.0.0 <2.0.0"
-  flutter_aepedgeidentity: ">= 1.0.0 <2.0.0"
+  flutter_aepcore: ">= 2.0.0 <3.0.0"
+  flutter_aepedgeidentity: ">= 2.0.0 <3.0.0"
  
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedgeconsent/android/build.gradle
+++ b/plugins/flutter_aepedgeconsent/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 19

--- a/plugins/flutter_aepedgeconsent/android/build.gradle
+++ b/plugins/flutter_aepedgeconsent/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.adobe.marketing.mobile.flutter.flutter_aepedgeconsent'
-version '1.0'
+version '2.0'
 
 buildscript {
     repositories {
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.1'
     }
 }
 
@@ -22,11 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 19
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.adobe.marketing.mobile:edgeconsent:1.+'
+    api 'com.adobe.marketing.mobile:edgeconsent:2.+'
 }

--- a/plugins/flutter_aepedgeconsent/android/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/flutter_aepedgeconsent/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/plugins/flutter_aepedgeconsent/pubspec.yaml
+++ b/plugins/flutter_aepedgeconsent/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_aepedgeconsent
 
 description: Official Adobe Experience Platform support for Flutter apps. The AEP Consent Collection plugin enables consent preferences collection from your Flutter app when using the Adobe Experience Platform Mobile SDK and the Edge Network extension.
-version: 1.0.0
+version: 2.0.0
 homepage: https://aep-sdks.gitbook.io/docs/
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepedgeconsent
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 1.0.0 <2.0.0"
+  flutter_aepcore: ">= 2.0.0 <3.0.0"
  
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedgeidentity/android/build.gradle
+++ b/plugins/flutter_aepedgeidentity/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.adobe.marketing.mobile.flutter.flutter_aepedgeidentity'
-version '1.0'
+version '2.0'
 
 buildscript {
     repositories {
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.1'
     }
 }
 
@@ -22,11 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 19
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.adobe.marketing.mobile:edgeidentity:1+'
+    api 'com.adobe.marketing.mobile:edgeidentity:2.+'
 }

--- a/plugins/flutter_aepedgeidentity/android/build.gradle
+++ b/plugins/flutter_aepedgeidentity/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 19

--- a/plugins/flutter_aepedgeidentity/android/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/flutter_aepedgeidentity/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/plugins/flutter_aepedgeidentity/pubspec.yaml
+++ b/plugins/flutter_aepedgeidentity/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_aepedgeidentity
 
 description: Official Adobe Experience Platform support for Flutter apps. The Experience Platform Edge Identity extension enables handling of user identity data from a mobile app when using the Adobe Experience Platform SDK and the Edge Network extension.
-version: 1.0.0
+version: 2.0.0
 homepage: https://aep-sdks.gitbook.io/docs/
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepedgeidentity
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 1.0.0 <2.0.0"
+  flutter_aepcore: ">= 2.0.0 <3.0.0"
  
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Update Android dependencies to latest version
Removed support libraries, updates android target, compile SDK. 
Updated registration logic in example application. 

Individual packages are experiencing build failures because the version 2.0.0 of `flutter_aepcore` has not been published.