### PR TITLE
Bug fixes in existing plugins 

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - staging
+      - android_2x 
     paths:
       - 'plugins/**'
       - 'example/**'
@@ -11,6 +12,7 @@ on:
     branches:
       - main
       - staging
+      - android_2x 
     paths:
       - 'plugins/**'
       - 'example/**'

--- a/plugins/flutter_aepassurance/android/src/main/java/com/adobe/marketing/mobile/flutter/FlutterAEPAssurancePlugin.java
+++ b/plugins/flutter_aepassurance/android/src/main/java/com/adobe/marketing/mobile/flutter/FlutterAEPAssurancePlugin.java
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.flutter;
 
 import android.util.Log;
 
+import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Assurance;
 
 import androidx.annotation.NonNull;
@@ -50,10 +51,11 @@ public class FlutterAEPAssurancePlugin implements FlutterPlugin, MethodCallHandl
       String url = (String) call.arguments;
       if (url.isEmpty()) {
         Log.e(TAG, "Unable to start assurance session, argument parsing failed");
-        return;
+        result.error(String.valueOf(AdobeError.UNEXPECTED_ERROR.getErrorCode()), AdobeError.UNEXPECTED_ERROR.getErrorName(), null);
+      } else {
+        Assurance.startSession(url);
+        result.success(null);
       }
-      Assurance.startSession(url);
-      result.success(null);
     } else {
       result.notImplemented();
     }

--- a/plugins/flutter_aepassurance/ios/flutter_aepassurance.podspec
+++ b/plugins/flutter_aepassurance/ios/flutter_aepassurance.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepassurance'
-  s.version          = '1.0.0'
+  s.version          = '2.0.0'
   s.summary          = 'Adobe Experience Platform support for Flutter apps.'
   s.homepage         = 'https://aep-sdks.gitbook.io/docs/'
   s.license          = { :file => '../LICENSE' }

--- a/plugins/flutter_aepassurance/pubspec.yaml
+++ b/plugins/flutter_aepassurance/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dependency_overrides:
   flutter_aepcore:
-    path: ../plugins/flutter_aepcore
+    path: ../flutter_aepcore
 
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepassurance/pubspec.yaml
+++ b/plugins/flutter_aepassurance/pubspec.yaml
@@ -15,6 +15,10 @@ dependencies:
     sdk: flutter
   flutter_aepcore: ">= 2.0.0 <3.0.0"
 
+dependency_overrides:
+  flutter_aepcore:
+    path: ../plugins/flutter_aepcore
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/plugins/flutter_aepcore/android/src/main/java/com/adobe/marketing/mobile/flutter/FlutterAEPIdentityPlugin.java
+++ b/plugins/flutter_aepcore/android/src/main/java/com/adobe/marketing/mobile/flutter/FlutterAEPIdentityPlugin.java
@@ -15,6 +15,8 @@ package com.adobe.marketing.mobile.flutter;
 import android.util.Log;
 
 import com.adobe.marketing.mobile.AdobeCallback;
+import com.adobe.marketing.mobile.AdobeCallbackWithError;
+import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Identity;
 import com.adobe.marketing.mobile.VisitorID;
 
@@ -65,6 +67,7 @@ public class FlutterAEPIdentityPlugin implements FlutterPlugin, MethodChannel.Me
             result.success(null);
         } else if("syncIdentifiersWithAuthState".equals(call.method)) {
             handleSyncIdentifiersWithAuthState(call.arguments);
+            result.success(null);
         } else if("urlVariables".equals(call.method)) {
             handleUrlVariables(result);
         } else {
@@ -73,52 +76,54 @@ public class FlutterAEPIdentityPlugin implements FlutterPlugin, MethodChannel.Me
     }
 
     private void handleAppendToUrl(final MethodChannel.Result result, final Object arguments) {
-        if (arguments instanceof String) {
-            Identity.appendVisitorInfoForURL((String) arguments, new AdobeCallback<String>() {
-                @Override
-                public void call(final String url) {
-                    AndroidUtil.runOnUIThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            result.success(url);
-                        }
-                    });
-                }
-            });
-        } else {
+        if (!(arguments instanceof String)) {
             Log.e(TAG, "Failed to handle append to url, url is not string");
+            result.error(Integer.toString(AdobeError.UNEXPECTED_ERROR.getErrorCode()),AdobeError.UNEXPECTED_ERROR.getErrorName(), null);
+            return;
         }
+        Identity.appendVisitorInfoForURL((String) arguments, new AdobeCallbackWithError<String>() {
+            @Override
+            public void call(final String url) {
+                AndroidUtil.runOnUIThread(() -> result.success(url));
+            }
+            @Override
+            public void fail(AdobeError adobeError) {
+                final AdobeError error = adobeError != null ? adobeError : AdobeError.UNEXPECTED_ERROR;
+                AndroidUtil.runOnUIThread(() -> result.error(Integer.toString(error.getErrorCode()),"getIdentifiers - Failed to retrieve Identifiers",error.getErrorName()));
+            }
+        });
     }
 
     private void handleGetIdentifiers(final MethodChannel.Result result) {
-        Identity.getIdentifiers(new AdobeCallback<List<VisitorID>>() {
-
+        Identity.getIdentifiers(new AdobeCallbackWithError<List<VisitorID>>() {
             @Override
             public void call(List<VisitorID> visitorIDS) {
                 final List<Map> ids = new ArrayList<>();
                 for (VisitorID visitor: visitorIDS) {
                     ids.add(FlutterAEPIdentityDataBridge.mapFromVisitorIdentifier(visitor));
                 }
-                AndroidUtil.runOnUIThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        result.success(ids);
-                    }
-                });
+                AndroidUtil.runOnUIThread(() -> result.success(ids));
+            }
+
+            @Override
+            public void fail(AdobeError adobeError) {
+                final AdobeError error = adobeError != null ? adobeError : AdobeError.UNEXPECTED_ERROR;
+                AndroidUtil.runOnUIThread(() -> result.error(Integer.toString(error.getErrorCode()),"getIdentifiers - Failed to retrieve Identifiers",error.getErrorName()));
             }
         });
     }
 
     private void handleGetExperienceCloudId(final MethodChannel.Result result) {
-        Identity.getExperienceCloudId(new AdobeCallback<String>() {
+        Identity.getExperienceCloudId(new AdobeCallbackWithError<String>() {
             @Override
-            public void call(final String couldId) {
-                AndroidUtil.runOnUIThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        result.success(couldId);
-                    }
-                });
+            public void call(final String experienceCloudId) {
+                AndroidUtil.runOnUIThread(() -> result.success(experienceCloudId));
+            }
+
+            @Override
+            public void fail(final AdobeError adobeError) {
+                final AdobeError error = adobeError != null ? adobeError : AdobeError.UNEXPECTED_ERROR;
+                AndroidUtil.runOnUIThread(() -> result.error(Integer.toString(error.getErrorCode()),"getExperienceCloudId - Failed to retrieve Experience Cloud Id",error.getErrorName()));
             }
         });
     }
@@ -132,6 +137,7 @@ public class FlutterAEPIdentityPlugin implements FlutterPlugin, MethodChannel.Me
         Map<String, Object> params = (Map<String, Object>) arguments;
         if (!(params.get("identifierType") instanceof String) || !(params.get("identifier") instanceof String) || !(params.get("authState") instanceof String)) {
             Log.e(TAG, "Sync identifier failed because arguments were invalid");
+            return;
         }
 
         String identifierType = (String) params.get("identifierType");
@@ -159,22 +165,25 @@ public class FlutterAEPIdentityPlugin implements FlutterPlugin, MethodChannel.Me
         Map params = (Map) arguments;
         if (!(params.get("identifiers") instanceof Map) && !(params.get("authState") instanceof String)) {
             Log.e(TAG, "Sync identifier failed because arguments were invalid");
+            return;
         }
+
         Map identifiers = (Map) params.get("identifiers");
         VisitorID.AuthenticationState authenticationState = FlutterAEPIdentityDataBridge.authenticationStateFromString((String) params.get("authState"));
         Identity.syncIdentifiers(identifiers, authenticationState);
     }
 
     private void handleUrlVariables(final MethodChannel.Result result) {
-        Identity.getUrlVariables(new AdobeCallback<String>() {
+        Identity.getUrlVariables(new AdobeCallbackWithError<String>() {
             @Override
             public void call(final String urlVariables) {
-                AndroidUtil.runOnUIThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        result.success(urlVariables);
-                    }
-                });
+                AndroidUtil.runOnUIThread(() -> result.success(urlVariables));
+            }
+
+            @Override
+            public void fail(final AdobeError adobeError) {
+                final AdobeError error = adobeError != null ? adobeError : AdobeError.UNEXPECTED_ERROR;
+                AndroidUtil.runOnUIThread(() -> result.error(Integer.toString(error.getErrorCode()),"getUrlVariables - failed to retrieve the URL variables",error.getErrorName()));
             }
         });
     }

--- a/plugins/flutter_aepcore/ios/Classes/FlutterAEPCorePlugin.m
+++ b/plugins/flutter_aepcore/ios/Classes/FlutterAEPCorePlugin.m
@@ -40,7 +40,7 @@ governing permissions and limitations under the License.
         [AEPMobileCore setAdvertisingIdentifier:aid];
         result(nil);
     } else if ([@"dispatchEvent" isEqualToString:call.method]) {
-        [self handleDispatchEvent:call];
+        [self handleDispatchEvent:call result:result];
     } else if ([@"dispatchEventWithResponseCallback" isEqualToString:call.method]) {
         [self handleDispatchEventWithResponseCallback:call result:result];
     } else if ([@"getSdkIdentities" isEqualToString:call.method]) {
@@ -63,10 +63,13 @@ governing permissions and limitations under the License.
         result(nil);
     } else if ([@"setAppGroup" isEqualToString:call.method]) {
         [self handleSetAppGroup:call];
+        result(nil);
     } else if ([@"collectPii" isEqualToString:call.method]) {
         [self handleCollectPii:call];
+        result(nil);
     } else if ([@"resetIdentities" isEqualToString:call.method]) {
         [self handleResetIdentities:call];
+        result(nil);
     } else {
         result(FlutterMethodNotImplemented);
     }
@@ -86,15 +89,29 @@ governing permissions and limitations under the License.
     
 }
 
-- (void)handleDispatchEvent:(FlutterMethodCall *) call {
+- (void)handleDispatchEvent:(FlutterMethodCall *) call
+    result:(FlutterResult)result {
     NSDictionary *eventDict = (NSDictionary *) call.arguments;
     AEPEvent *event = [AEPEvent eventFromDictionary:eventDict];
+    if (event == nil) {
+        FlutterError* error = [FlutterError errorWithCode:[NSString stringWithFormat:@"%ld", AEPErrorUnexpected] message:@"Unexpected error" details:nil];
+        
+        result(error);
+        return;
+    }
     [AEPMobileCore dispatch:event];
+    result(nil);
 }
 
 - (void)handleDispatchEventWithResponseCallback:(FlutterMethodCall *) call result:(FlutterResult)result {
     NSDictionary *eventDict = (NSDictionary *) call.arguments;
     AEPEvent *event = [AEPEvent eventFromDictionary:eventDict];
+    if (event == nil) {
+        FlutterError* error = [FlutterError errorWithCode:[NSString stringWithFormat:@"%ld", AEPErrorUnexpected] message:@"Unexpected error" details:nil];
+        
+        result(error);
+        return;
+    }
     
     [AEPMobileCore dispatch:event timeout:1 responseCallback:^(AEPEvent * _Nullable responseEvent) {
         result([AEPEvent dictionaryFromEvent:responseEvent]);

--- a/plugins/flutter_aepcore/ios/flutter_aepcore.podspec
+++ b/plugins/flutter_aepcore/ios/flutter_aepcore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepcore'
-  s.version          = '0.0.1'
+  s.version          = '2.0.0'
   s.summary          = 'Adobe Experience Platform support for Flutter apps.'
   s.homepage         = 'https://aep-sdks.gitbook.io/docs/'
   s.license          = { :file => '../LICENSE' }

--- a/plugins/flutter_aepcore/lib/flutter_aepcore.dart
+++ b/plugins/flutter_aepcore/lib/flutter_aepcore.dart
@@ -57,9 +57,8 @@ class MobileCore {
       _channel.invokeMethod<void>('setAdvertisingIdentifier', aid);
 
   ///  Called by the extension public API to dispatch an event for other extensions or the internal SDK to consume. Any events dispatched by this call will not be processed until after `start` has been called.
-  static Future<bool> dispatchEvent(Event event) => _channel
-      .invokeMethod<bool>('dispatchEvent', event.data)
-      .then((value) => value!);
+  static Future<void> dispatchEvent(Event event) => _channel
+      .invokeMethod<void>('dispatchEvent', event.data);
 
   /// You should use this method when the Event being passed is a request and you expect an event in response. Any events dispatched by this call will not be processed until after `start` has been called.
   static Future<Event> dispatchEventWithResponseCallback(

--- a/plugins/flutter_aepcore/test/flutter_aepcore_test.dart
+++ b/plugins/flutter_aepcore/test/flutter_aepcore_test.dart
@@ -159,9 +159,6 @@ void main() {
       ]);
     });
 
-    test('returns correct result', () async {
-      expect(await MobileCore.dispatchEvent(expectedEvent), true);
-    });
   });
 
   group('dispatchEventWithResponseCallback', () {

--- a/plugins/flutter_aepedge/ios/flutter_aepedge.podspec
+++ b/plugins/flutter_aepedge/ios/flutter_aepedge.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepedge'
-  s.version          = '1.0.0'
+  s.version          = '2.0.0'
   s.summary          = 'Adobe Experience Platform Edge Network extension for Flutter apps.'
   s.homepage         = 'https://aep-sdks.gitbook.io/docs/'
   s.license          = { :file => '../LICENSE' }

--- a/plugins/flutter_aepedge/pubspec.yaml
+++ b/plugins/flutter_aepedge/pubspec.yaml
@@ -17,7 +17,9 @@ dependencies:
 
 dependency_overrides:
   flutter_aepcore:
-    path: ../plugins/flutter_aepcore
+    path: ../flutter_aepcore
+  flutter_aepedgeidentity:
+    path: ../flutter_aepedgeidentity
 
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedge/pubspec.yaml
+++ b/plugins/flutter_aepedge/pubspec.yaml
@@ -14,7 +14,11 @@ dependencies:
     sdk: flutter
   flutter_aepcore: ">= 2.0.0 <3.0.0"
   flutter_aepedgeidentity: ">= 2.0.0 <3.0.0"
- 
+
+dependency_overrides:
+  flutter_aepcore:
+    path: ../plugins/flutter_aepcore
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/plugins/flutter_aepedgeconsent/android/src/main/java/com/adobe/marketing/mobile/flutter/flutter_aepedgeconsent/FlutterAEPEdgeConsentPlugin.java
+++ b/plugins/flutter_aepedgeconsent/android/src/main/java/com/adobe/marketing/mobile/flutter/flutter_aepedgeconsent/FlutterAEPEdgeConsentPlugin.java
@@ -49,24 +49,14 @@ public class FlutterAEPEdgeConsentPlugin implements FlutterPlugin, MethodCallHan
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     if ("extensionVersion".equals(call.method)) {
-      AndroidUtil.runOnUIThread(new Runnable() {
-        @Override
-        public void run() {
-          result.success(Consent.extensionVersion());
-        }
-      });
+        result.success(Consent.extensionVersion());
     } else if("getConsents".equals(call.method)) {
-            handleGetConsents(result);
+        handleGetConsents(result);
     } else if("updateConsents".equals(call.method)) {
-            handleUpdateConsents(call.arguments);
-            result.success(null);
+        handleUpdateConsents(call.arguments);
+        result.success(null);
     } else {
-      AndroidUtil.runOnUIThread(new Runnable() {
-        @Override
-        public void run() {
-          result.notImplemented();
-        }
-      });
+        result.notImplemented();
     }
   }
 
@@ -74,23 +64,13 @@ public class FlutterAEPEdgeConsentPlugin implements FlutterPlugin, MethodCallHan
       Consent.getConsents(new AdobeCallbackWithError<Map<String, Object>>() {
           @Override
           public void call(final Map<String, Object> consents) {
-              AndroidUtil.runOnUIThread(new Runnable() {
-                  @Override
-                  public void run() {
-                      result.success(consents);
-                  }
-              });
+              AndroidUtil.runOnUIThread(() -> result.success(consents));
           }
 
           @Override
           public void fail(final AdobeError adobeError) {
             final AdobeError error = adobeError != null ? adobeError : AdobeError.UNEXPECTED_ERROR;
-            AndroidUtil.runOnUIThread(new Runnable() {
-              @Override
-              public void run() {
-                result.error(Integer.toString(error.getErrorCode()),"getConsents - Failed to retrieve consents",error.getErrorName());
-              }
-            });
+            AndroidUtil.runOnUIThread(() -> result.error(Integer.toString(error.getErrorCode()),"getConsents - Failed to retrieve consents",error.getErrorName()));
           }
       });
   }

--- a/plugins/flutter_aepedgeconsent/ios/flutter_aepedgeconsent.podspec
+++ b/plugins/flutter_aepedgeconsent/ios/flutter_aepedgeconsent.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepedgeconsent'
-  s.version          = '1.0.0'
+  s.version          = '2.0.0'
   s.summary          = 'Adobe Experience Platform Consent Collection support for Flutter apps.'
   s.homepage         = 'https://aep-sdks.gitbook.io/docs/'
   s.license          = { :file => '../LICENSE' }

--- a/plugins/flutter_aepedgeconsent/pubspec.yaml
+++ b/plugins/flutter_aepedgeconsent/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 
 dependency_overrides:
   flutter_aepcore:
-    path: ../plugins/flutter_aepcore
+    path: ../flutter_aepcore
  
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedgeconsent/pubspec.yaml
+++ b/plugins/flutter_aepedgeconsent/pubspec.yaml
@@ -13,6 +13,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_aepcore: ">= 2.0.0 <3.0.0"
+
+dependency_overrides:
+  flutter_aepcore:
+    path: ../plugins/flutter_aepcore
  
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedgeidentity/android/src/main/java/com/adobe/marketing/mobile/flutter/flutter_aepedgeidentity/FlutterAEPEdgeIdentityPlugin.java
+++ b/plugins/flutter_aepedgeidentity/android/src/main/java/com/adobe/marketing/mobile/flutter/flutter_aepedgeidentity/FlutterAEPEdgeIdentityPlugin.java
@@ -53,18 +53,13 @@ public class FlutterAEPEdgeIdentityPlugin implements FlutterPlugin, MethodCallHa
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     if ("extensionVersion".equals(call.method)) {
-      AndroidUtil.runOnUIThread(new Runnable() {
-        @Override
-        public void run() {
-           result.success(Identity.extensionVersion());
-        }
-      });
+        result.success(Identity.extensionVersion());
     } else if ("getExperienceCloudId".equals(call.method)) {
          handleGetExperienceCloudId(result);
     } else if ("getUrlVariables".equals(call.method)) {
          handleGetUrlVariables(result);
     } else if ("getIdentities".equals(call.method)) {
-          handleGetIdentities(result);
+         handleGetIdentities(result);
     } else if ("updateIdentities".equals(call.method)) {
          handleUpdateIdentities(call.arguments);
          result.success(null);
@@ -73,14 +68,9 @@ public class FlutterAEPEdgeIdentityPlugin implements FlutterPlugin, MethodCallHa
          String namespace = call.argument("namespace");
          handleRemoveIdentity(item, namespace);
          result.success(null);
-  }
+    }
     else {
-      AndroidUtil.runOnUIThread(new Runnable() {
-        @Override
-        public void run() {
-           result.notImplemented();
-        }
-      });
+        result.notImplemented();
     }
   }
 
@@ -88,23 +78,13 @@ public class FlutterAEPEdgeIdentityPlugin implements FlutterPlugin, MethodCallHa
     Identity.getExperienceCloudId(new AdobeCallbackWithError<String>() {
         @Override
         public void call(final String experienceCloudId) {
-            AndroidUtil.runOnUIThread(new Runnable() {
-                @Override
-                public void run() {
-                    result.success(experienceCloudId);
-                }
-            });
+            AndroidUtil.runOnUIThread(() -> result.success(experienceCloudId));
         }
 
         @Override
         public void fail(final AdobeError adobeError) {
           final AdobeError error = adobeError != null ? adobeError : AdobeError.UNEXPECTED_ERROR;
-          AndroidUtil.runOnUIThread(new Runnable() {
-            @Override
-            public void run() {
-              result.error(Integer.toString(error.getErrorCode()),"getExperienceCloudId - Failed to retrieve Experience Cloud Id",error.getErrorName());
-            }
-          });
+          AndroidUtil.runOnUIThread(() -> result.error(Integer.toString(error.getErrorCode()),"getExperienceCloudId - Failed to retrieve Experience Cloud Id",error.getErrorName()));
         } 
     });
   }
@@ -113,23 +93,13 @@ public class FlutterAEPEdgeIdentityPlugin implements FlutterPlugin, MethodCallHa
       Identity.getUrlVariables(new AdobeCallbackWithError<String>() {
           @Override
           public void call(final String urlVariables) {
-              AndroidUtil.runOnUIThread(new Runnable() {
-                  @Override
-                  public void run() {
-                      result.success(urlVariables);
-                  }
-              });
+              AndroidUtil.runOnUIThread(() -> result.success(urlVariables));
           }
 
           @Override
           public void fail(final AdobeError adobeError) {
             final AdobeError error = adobeError != null ? adobeError : AdobeError.UNEXPECTED_ERROR;
-            AndroidUtil.runOnUIThread(new Runnable() {
-              @Override
-              public void run() {
-                result.error(Integer.toString(error.getErrorCode()),"getUrlVariables - failed to retrieve the URL variables",error.getErrorName());
-              }
-            });
+            AndroidUtil.runOnUIThread(() -> result.error(Integer.toString(error.getErrorCode()),"getUrlVariables - failed to retrieve the URL variables",error.getErrorName()));
           }
       });
   }
@@ -138,24 +108,16 @@ public class FlutterAEPEdgeIdentityPlugin implements FlutterPlugin, MethodCallHa
     Identity.getIdentities(new AdobeCallbackWithError<IdentityMap>() {
         @Override
         public void call(IdentityMap map) {
-            AndroidUtil.runOnUIThread(new Runnable() {
-                @Override
-                public void run() {
-                    Map identityMap = FlutterAEPEdgeIdentityDataBridge.mapFromIdentityMap(map);
-                    result.success(identityMap);
-                }
+            AndroidUtil.runOnUIThread(() -> {
+                Map identityMap = FlutterAEPEdgeIdentityDataBridge.mapFromIdentityMap(map);
+                result.success(identityMap);
             });
         }
 
         @Override
         public void fail(final AdobeError adobeError) {
           final AdobeError error = adobeError != null ? adobeError : AdobeError.UNEXPECTED_ERROR;
-          AndroidUtil.runOnUIThread(new Runnable() {
-            @Override
-            public void run() {
-              result.error(Integer.toString(error.getErrorCode()),"getIdentity - Failed to retrieve identities",error.getErrorName());
-            }
-          });
+          AndroidUtil.runOnUIThread(() -> result.error(Integer.toString(error.getErrorCode()),"getIdentity - Failed to retrieve identities",error.getErrorName()));
         }
     });
   }
@@ -163,8 +125,8 @@ public class FlutterAEPEdgeIdentityPlugin implements FlutterPlugin, MethodCallHa
  @SuppressLint("LongLogTag")
   private void handleUpdateIdentities(final Object arguments) {
     if (!(arguments instanceof Map)) {
-    Log.e(TAG, "Updating Identities failed, passed IdentityMap is invalid");
-    return;
+        Log.e(TAG, "Updating Identities failed, passed IdentityMap is invalid");
+        return;
     }
 
     Map<String,Map<String,List<Map<String,Object>>>> map = (Map) arguments;

--- a/plugins/flutter_aepedgeidentity/ios/flutter_aepedgeidentity.podspec
+++ b/plugins/flutter_aepedgeidentity/ios/flutter_aepedgeidentity.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepedgeidentity'
-  s.version          = '1.0.0'
+  s.version          = '2.0.0'
   s.summary          = 'Adobe Experience Platform Identity for Edge Network extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe.'
   s.homepage         = 'https://aep-sdks.gitbook.io/docs/'
   s.license          = { :file => '../LICENSE' }

--- a/plugins/flutter_aepedgeidentity/pubspec.yaml
+++ b/plugins/flutter_aepedgeidentity/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 
 dependency_overrides:
   flutter_aepcore:
-    path: ../plugins/flutter_aepcore
+    path: ../flutter_aepcore
  
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedgeidentity/pubspec.yaml
+++ b/plugins/flutter_aepedgeidentity/pubspec.yaml
@@ -13,6 +13,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_aepcore: ">= 2.0.0 <3.0.0"
+
+dependency_overrides:
+  flutter_aepcore:
+    path: ../plugins/flutter_aepcore
  
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
1) Update dispatchEvent signature to 
`static Future<void> dispatchEvent(Event event)`

2) Plugins should handle the methods by either calling `result.error` or `result.success` to complete the future returned by Flutter API. I have fixed issues where we just return without completing future in case of error. 

3) Removed redundant calls to `AndroidUtil.runOnUIThread` in `onMethodCall` function. 

To avoid build failures, added following block to resolving core dependency by using local path. Remove it after Core 2.0 release.
```
dependency_overrides:
  flutter_aepcore:
    path: ../flutter_aepcore
```
