### PR TITLE
Staging -> Main for 3.0 Releases

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -11,7 +11,7 @@ Update your `pubspec.yml` file to point to the new plugin as so:
 
 dependencies:
 -  flutter_acpcore: ^2.0.0
-+  flutter_aepcore: ^2.0.0
++  flutter_aepcore: ^3.0.0
 
 ...
 ```

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,19 +14,19 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
 
-  flutter_aepcore: ">= 2.0.0 <3.0.0"
+  flutter_aepcore: ">= 3.0.0 <4.0.0"
 
-  flutter_aepassurance: ">= 2.0.0 <3.0.0"
+  flutter_aepassurance: ">= 3.0.0 <4.0.0"
 
-  flutter_aepedge: ">= 2.0.0 <3.0.0"
+  flutter_aepedge: ">= 3.0.0 <4.0.0"
 
-  flutter_aepedgeconsent: ">= 2.0.0 <3.0.0"
+  flutter_aepedgeconsent: ">= 3.0.0 <4.0.0"
 
-  flutter_aepedgeidentity: ">= 2.0.0 <3.0.0" 
+  flutter_aepedgeidentity: ">= 3.0.0 <4.0.0" 
 
-  flutter_aepedgebridge: ">= 1.0.0 <2.0.0"  
+  flutter_aepedgebridge: ">= 3.0.0 <4.0.0"  
 
-  flutter_aepuserprofile: ">= 1.0.0 <2.0.0"  
+  flutter_aepuserprofile: ">= 3.0.0 <4.0.0"  
 
 dependency_overrides:
   flutter_aepcore:

--- a/plugins/flutter_aepassurance/CHANGELOG.md
+++ b/plugins/flutter_aepassurance/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+* Adobe Mobile SDK for iOS 4.x support
+* Updated minimum supported version to iOS 11.0
+
 ## 2.0.0
 
 * Adobe Mobile SDK for Android 2.x support.

--- a/plugins/flutter_aepassurance/ios/flutter_aepassurance.podspec
+++ b/plugins/flutter_aepassurance/ios/flutter_aepassurance.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepassurance'
-  s.version          = '2.0.0'
+  s.version          = '3.0.0'
   s.summary          = 'Adobe Experience Platform support for Flutter apps.'
   s.homepage         = 'https://developer.adobe.com/client-sdks'
   s.license          = { :file => '../LICENSE' }
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AEPAssurance', '~> 3.0'
-  s.platform = :ios, '10.0'
+  s.dependency 'AEPAssurance', '~> 4.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
 end

--- a/plugins/flutter_aepassurance/pubspec.yaml
+++ b/plugins/flutter_aepassurance/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_aepassurance
 
 description: Official Adobe Experience Platform support for Flutter apps. Assurance is a new, innovative product from Adobe to help you easily validate SDK implementations.
-version: 2.0.0
+version: 3.0.0
 
 homepage: https://developer.adobe.com/client-sdks
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepassurance
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 2.0.0 <3.0.0"
+  flutter_aepcore: ">= 3.0.0 <4.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepcore/CHANGELOG.md
+++ b/plugins/flutter_aepcore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+* Adobe Mobile SDK for iOS 4.x support
+* Updated minimum supported version to iOS 11.0
+
 ## 2.0.0
 
 * Adobe Mobile SDK for Android 2.x support.

--- a/plugins/flutter_aepcore/README.md
+++ b/plugins/flutter_aepcore/README.md
@@ -58,8 +58,6 @@ MobileCore.clearUpdatedConfiguration();
 
 ##### Controlling the log level of the SDK:
 ```dart
-import 'package:flutter_aepcore/flutter_aepcore_data.dart';
-
 MobileCore.setLogLevel(LogLevel.error);
 MobileCore.setLogLevel(LogLevel.warning);
 MobileCore.setLogLevel(LogLevel.debug);
@@ -68,8 +66,6 @@ MobileCore.setLogLevel(LogLevel.trace);
 
 ##### Getting the current privacy status:
 ```dart
-import 'package:flutter_aepcore/flutter_aepcore_data.dart';
-
 PrivacyStatus result;
 
 try {
@@ -81,8 +77,6 @@ try {
 
 ##### Setting the privacy status:
 ```dart
-import 'package:flutter_aepcore/flutter_aepcore_data.dart';
-
 MobileCore.setPrivacyStatus(PrivacyStatus.opt_in);
 MobileCore.setPrivacyStatus(PrivacyStatus.opt_out);
 MobileCore.setPrivacyStatus(PrivacyStatus.unknown);
@@ -101,8 +95,6 @@ try {
 
 ##### Dispatching an Event Hub event:
 ```dart
-import 'package:flutter_aepcore/flutter_aepcore_data.dart';
-
 final Event event = Event({
   "eventName": "testEventName",
   "eventType": "testEventType",
@@ -118,8 +110,6 @@ try {
 
 ##### Dispatching an Event Hub event with callback:
 ```dart
-import 'package:flutter_aepcore/flutter_aepcore_data.dart';
-
 Event result;
 final Event event = Event({
       "eventName": "testEventName",
@@ -164,8 +154,6 @@ String version = await Identity.extensionVersion;
 
 ##### Sync Identifier:
 ```dart
-import 'package:flutter_aepcore/flutter_aepcore_data.dart';
-
 Identity.syncIdentifier("identifierType", "identifier", MobileVisitorAuthenticationState.authenticated);
 ```
 
@@ -178,8 +166,6 @@ Identity.syncIdentifiers({"idType1":"idValue1",
 
 ##### Sync Identifiers with Authentication State:
 ```dart
-import 'package:flutter_aepcore/flutter_aepcore_data.dart';
-
 Identity.syncIdentifiersWithAuthState({"idType1":"idValue1", "idType2":"idValue2", "idType3":"idValue3"}, MobileVisitorAuthenticationState.authenticated);
 
 ```
@@ -245,8 +231,6 @@ try {
 
 ##### AEPMobileVisitorId Class:
 ```dart
-import 'package:flutter_aepcore/flutter_aepcore_data.dart';
-
 class Identifiable {
   String get idOrigin;
   String get idType;

--- a/plugins/flutter_aepcore/ios/flutter_aepcore.podspec
+++ b/plugins/flutter_aepcore/ios/flutter_aepcore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepcore'
-  s.version          = '2.0.0'
+  s.version          = '3.0.0'
   s.summary          = 'Adobe Experience Platform support for Flutter apps.'
   s.homepage         = 'https://developer.adobe.com/client-sdks'
   s.license          = { :file => '../LICENSE' }
@@ -9,11 +9,11 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AEPCore', '~> 3.0'
-  s.dependency 'AEPLifecycle', '~> 3.0'
-  s.dependency 'AEPIdentity', '~> 3.0'
-  s.dependency 'AEPSignal', '~> 3.0'
-  s.platform = :ios, '10.0'
+  s.dependency 'AEPCore', '~> 4.0'
+  s.dependency 'AEPLifecycle', '~> 4.0'
+  s.dependency 'AEPIdentity', '~> 4.0'
+  s.dependency 'AEPSignal', '~> 4.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/plugins/flutter_aepcore/lib/flutter_aepcore.dart
+++ b/plugins/flutter_aepcore/lib/flutter_aepcore.dart
@@ -12,9 +12,8 @@ governing permissions and limitations under the License.
 import 'dart:async';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_aepcore/src/aepextension_event.dart';
-import 'package:flutter_aepcore/src/aepmobile_logging_level.dart';
-import 'package:flutter_aepcore/src/aepmobile_privacy_status.dart';
+import 'package:flutter_aepcore/flutter_aepcore_data.dart';
+export 'package:flutter_aepcore/flutter_aepcore_data.dart';
 
 /// Adobe Experience Platform Core API.
 class MobileCore {

--- a/plugins/flutter_aepcore/lib/flutter_aepidentity.dart
+++ b/plugins/flutter_aepcore/lib/flutter_aepidentity.dart
@@ -12,7 +12,8 @@ governing permissions and limitations under the License.
 import 'dart:async';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_aepcore/src/aepmobile_visitor_id.dart';
+import 'package:flutter_aepcore/flutter_aepcore_data.dart';
+export 'package:flutter_aepcore/flutter_aepcore_data.dart';
 
 /// Adobe Experience Platform Identity API.
 class Identity {

--- a/plugins/flutter_aepcore/pubspec.yaml
+++ b/plugins/flutter_aepcore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aepcore
 description: Official Adobe Experience Platform support for Flutter apps. The Mobile Core represents the core Adobe Experience Platform SDK that is required for every app implementation.
-version: 2.0.0
+version: 3.0.0
 homepage: https://developer.adobe.com/client-sdks
 repository: https://github.com/adobe/aepsdk-flutter/tree/main/plugins/flutter_aepcore
 

--- a/plugins/flutter_aepcore/test/flutter_aepcore_test.dart
+++ b/plugins/flutter_aepcore/test/flutter_aepcore_test.dart
@@ -11,9 +11,6 @@ governing permissions and limitations under the License.
 
 import 'package:flutter/services.dart';
 import 'package:flutter_aepcore/flutter_aepcore.dart';
-import 'package:flutter_aepcore/src/aepextension_event.dart';
-import 'package:flutter_aepcore/src/aepmobile_logging_level.dart';
-import 'package:flutter_aepcore/src/aepmobile_privacy_status.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/plugins/flutter_aepcore/test/flutter_aepidentity_test.dart
+++ b/plugins/flutter_aepcore/test/flutter_aepidentity_test.dart
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 
 import 'package:flutter/services.dart';
 import 'package:flutter_aepcore/flutter_aepidentity.dart';
-import 'package:flutter_aepcore/src/aepmobile_visitor_id.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/plugins/flutter_aepedge/CHANGELOG.md
+++ b/plugins/flutter_aepedge/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+* Adobe Mobile SDK for iOS 4.x support
+* Updated minimum supported version to iOS 11.0
+
 ## 2.0.0
 
 * Adobe Mobile SDK for Android 2.x support.

--- a/plugins/flutter_aepedge/ios/flutter_aepedge.podspec
+++ b/plugins/flutter_aepedge/ios/flutter_aepedge.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepedge'
-  s.version          = '2.0.0'
+  s.version          = '3.0.0'
   s.summary          = 'Adobe Experience Platform Edge Network extension for Flutter apps.'
   s.homepage         = 'https://developer.adobe.com/client-sdks'
   s.license          = { :file => '../LICENSE' }
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AEPEdge', '~> 1.0'
-  s.platform = :ios, '10.0'
+  s.dependency 'AEPEdge', '~> 4.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
 end

--- a/plugins/flutter_aepedge/pubspec.yaml
+++ b/plugins/flutter_aepedge/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_aepedge
 
 description: Official Adobe Experience Platform support for Flutter apps. The Experience Platform Edge extension enables sending data to the Adobe Experience Edge from a mobile device.
-version: 2.0.0
+version: 3.0.0
 homepage: https://developer.adobe.com/client-sdks
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepedge
 
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 2.0.0 <3.0.0"
-  flutter_aepedgeidentity: ">= 2.0.0 <3.0.0"
+  flutter_aepcore: ">= 3.0.0 <4.0.0"
+  flutter_aepedgeidentity: ">= 3.0.0 <4.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedgebridge/CHANGELOG.md
+++ b/plugins/flutter_aepedgebridge/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+* Adobe Mobile SDK for iOS 4.x support
+* Updated minimum supported version to iOS 11.0
+
 ## 1.0.0
 
 * Initial release candidate

--- a/plugins/flutter_aepedgebridge/ios/flutter_aepedgeBridge.podspec
+++ b/plugins/flutter_aepedgebridge/ios/flutter_aepedgeBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepedgebridge'
-  s.version          = '1.0.0'
+  s.version          = '3.0.0'
   s.summary          = 'Adobe Experience Platform Edge Bridge support for Flutter apps.'
   s.homepage         = 'https://developer.adobe.com/client-sdks'
   s.license          = { :file => '../LICENSE' }
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AEPEdgeBridge', '~> 1.0'
-  s.platform = :ios, '10.0'
+  s.dependency 'AEPEdgeBridge', '~> 4.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
 end

--- a/plugins/flutter_aepedgebridge/pubspec.yaml
+++ b/plugins/flutter_aepedgebridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aepedgebridge
 description: Official Adobe Experience Platform support for Flutter apps. The AEP Edge Bridge mobile extension provides seamless routing of data to the Adobe Experience Platform Edge Network for existing SDK implementations.
-version: 1.0.0
+version: 3.0.0
 homepage: https://developer.adobe.com/client-sdks
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepedgebridge
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 2.0.0 <3.0.0"
+  flutter_aepcore: ">= 3.0.0 <4.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedgeconsent/CHANGELOG.md
+++ b/plugins/flutter_aepedgeconsent/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+* Adobe Mobile SDK for iOS 4.x support
+* Updated minimum supported version to iOS 11.0
+
 ## 2.0.0
 
 * Adobe Mobile SDK for Android 2.x support.

--- a/plugins/flutter_aepedgeconsent/ios/flutter_aepedgeconsent.podspec
+++ b/plugins/flutter_aepedgeconsent/ios/flutter_aepedgeconsent.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepedgeconsent'
-  s.version          = '2.0.0'
+  s.version          = '3.0.0'
   s.summary          = 'Adobe Experience Platform Consent Collection support for Flutter apps.'
   s.homepage         = 'https://developer.adobe.com/client-sdks'
   s.license          = { :file => '../LICENSE' }
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AEPEdgeConsent', '~> 1.0'
-  s.platform = :ios, '10.0'
+  s.dependency 'AEPEdgeConsent', '~> 4.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
 end

--- a/plugins/flutter_aepedgeconsent/pubspec.yaml
+++ b/plugins/flutter_aepedgeconsent/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_aepedgeconsent
 
 description: Official Adobe Experience Platform support for Flutter apps. The AEP Consent Collection plugin enables consent preferences collection from your Flutter app when using the Adobe Experience Platform Mobile SDK and the Edge Network extension.
-version: 2.0.0
+version: 3.0.0
 homepage: https://developer.adobe.com/client-sdks
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepedgeconsent
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 2.0.0 <3.0.0"
+  flutter_aepcore: ">= 3.0.0 <4.0.0"
  
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepedgeidentity/CHANGELOG.md
+++ b/plugins/flutter_aepedgeidentity/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+* Adobe Mobile SDK for iOS 4.x support
+* Updated minimum supported version to iOS 11.0
+
 ## 2.0.0
 
 * Adobe Mobile SDK for Android 2.x support.

--- a/plugins/flutter_aepedgeidentity/ios/flutter_aepedgeidentity.podspec
+++ b/plugins/flutter_aepedgeidentity/ios/flutter_aepedgeidentity.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepedgeidentity'
-  s.version          = '2.0.0'
+  s.version          = '3.0.0'
   s.summary          = 'Adobe Experience Platform Identity for Edge Network extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe.'
   s.homepage         = 'https://developer.adobe.com/client-sdks'
   s.license          = { :file => '../LICENSE' }
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AEPEdgeIdentity', '~> 1.0'
-  s.platform = :ios, '10.0'
+  s.dependency 'AEPEdgeIdentity', '~> 4.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
 end

--- a/plugins/flutter_aepedgeidentity/pubspec.yaml
+++ b/plugins/flutter_aepedgeidentity/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_aepedgeidentity
 
 description: Official Adobe Experience Platform support for Flutter apps. The Experience Platform Edge Identity extension enables handling of user identity data from a mobile app when using the Adobe Experience Platform SDK and the Edge Network extension.
-version: 2.0.0
+version: 3.0.0
 homepage: https://developer.adobe.com/client-sdks
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepedgeidentity
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 2.0.0 <3.0.0"
+  flutter_aepcore: ">= 3.0.0 <4.0.0"
  
 dev_dependencies:
   flutter_test:

--- a/plugins/flutter_aepuserprofile/CHANGELOG.md
+++ b/plugins/flutter_aepuserprofile/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+* Adobe Mobile SDK for iOS 4.x support
+* Updated minimum supported version to iOS 11.0
+
 ## 1.0.0
 
 * Initial release candidate

--- a/plugins/flutter_aepuserprofile/ios/flutter_aepuserprofile.podspec
+++ b/plugins/flutter_aepuserprofile/ios/flutter_aepuserprofile.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_aepuserprofile'
-  s.version          = '1.0.0'
+  s.version          = '3.0.0'
   s.summary          = 'Adobe Experience Platform User Profile support for Flutter apps.'
   s.homepage         = 'https://developer.adobe.com/client-sdks'
   s.license          = { :file => '../LICENSE' }
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AEPUserProfile', '~> 3.0'
-  s.platform = :ios, '10.0'
+  s.dependency 'AEPUserProfile', '~> 4.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
 end

--- a/plugins/flutter_aepuserprofile/pubspec.yaml
+++ b/plugins/flutter_aepuserprofile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aepuserprofile
 description: Official Adobe Experience Platform support for Flutter apps. The UserProfile extension represents the Adobe Experience Platform SDK's Profile extension which helps manage profile attributes in the client.
-version: 1.0.0
+version: 3.0.0
 homepage: https://developer.adobe.com/client-sdks
 repository: https://github.com/adobe/aepsdk_flutter/tree/main/plugins/flutter_aepuserprofile
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_aepcore: ">= 2.0.0 <3.0.0"
+  flutter_aepcore: ">= 3.0.0 <4.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Bumps the major versions of all plugins to 3.x, aligning all of the major versions. Includes:

* iOS 11 minimum deployment version, previously 10
* Bumps all iOS AEP SDK extensions to 4.x
* Adds export for data classes in core plugin as per: #26 