### PR TITLE
fix: Return null instead of Kotlin.Unit over method channel for AEPMessaging

### DIFF
--- a/plugins/flutter_aepmessaging/android/src/main/kotlin/com/adobe/marketing/mobile/flutter/flutter_aepmessaging/FlutterAEPMessagingPlugin.kt
+++ b/plugins/flutter_aepmessaging/android/src/main/kotlin/com/adobe/marketing/mobile/flutter/flutter_aepmessaging/FlutterAEPMessagingPlugin.kt
@@ -23,9 +23,9 @@ class FlutterAEPMessagingPlugin : FlutterPlugin, MethodCallHandler {
   override fun onMethodCall(call: MethodCall, result: Result) {
     when (call.method) {
       // Messaging Methods
-      "extensionVersion" -> result.success(Messaging.extensionVersion())
+      "extensionVersion" -> this.extensionVersion(result)
       "getCachedMessages" -> this.getCachedMessages(result)
-      "refreshInAppMessages" -> result.success(Messaging.refreshInAppMessages())
+      "refreshInAppMessages" -> this.refreshInAppMessages(result)
       // Message Methods
       "clearMessage" -> this.clearMessage(call, result)
       "dismissMessage" -> this.dismissMessage(call, result)
@@ -38,8 +38,18 @@ class FlutterAEPMessagingPlugin : FlutterPlugin, MethodCallHandler {
     }
   }
 
+  private fun extensionVersion(result: Result) {
+    Messaging.extensionVersion()
+    result.success(null)
+  }
+
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
+  }
+
+  private fun refreshInAppMessages(result: Result) {
+    Messaging.refreshInAppMessages()
+    result.success(null)
   }
 
   private fun getCachedMessages(result: Result) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Empty return types in Kotlin functions return an object noted as [Kotlin.Unit.](https://kotlinlang.org/docs/functions.html#unit-returning-functions) which is not supported by [Flutter BinaryMessenger ](https://api.flutter.dev/flutter/services/BinaryMessenger-class.html).

`flutter_aepmessaging` throws a native exception regarding `Kotlin.Unit` being an unsupported type when calling `Messaging.refershInAppMessages()`. This native exception is never received on the Flutter side.

This update addresses all aepsdk_flutter 5.0.1 plugins passing Kotlin functions with undefined types to `MethodChannel.Result` by explicitly passing `null`

The plugins affected are
- `flutter_aepmessaging`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
While refreshing Adobe In-App Messages on Android via the Dart SDK, this issue was found. It is unknown the impact of the issue.

If a critical issue is not resolved, at least there's no more errors being reported in the logs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This issue is evident by writing an integration test for the example project and running the integration test on an Android device
```
import 'package:flutter_aepmessaging/flutter_aepmessaging.dart';
import 'package:flutter_test/flutter_test.dart';
import 'package:integration_test/integration_test.dart';

import '../lib/main.dart' as app; // Import your app's main

void main() {
  IntegrationTestWidgetsFlutterBinding.ensureInitialized();

  testWidgets('Android refreshInAppMessages does not throw exception',
      (tester) async {
    app.main();
    await tester.pumpAndSettle();

    try {
      Messaging.refreshInAppMessages();
    } on Exception {
      // Platform exception is never returned to flutter, so the logs have to be shown instead
      fail(
          'No exceptions should be thrown for calling [${Messaging.refreshInAppMessages}]');
    }
  });
}
```

## Screenshots (if appropriate):

Before:
<img width="1520" height="995" alt="Screenshot 2026-05-11 at 8 07 37 AM" src="https://github.com/user-attachments/assets/aa3e458d-64fe-4340-929f-ba925835a1b2" />

After:
<img width="1519" height="996" alt="Screenshot 2026-05-11 at 8 07 49 AM" src="https://github.com/user-attachments/assets/4fec7f71-d202-4293-b440-0b6e122c89a2" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
