### PR TITLE
[MOB-24978] refresh InApp bug fix

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -37,7 +37,7 @@ jobs:
 
   job2:
     name: Build iOS example app
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v1

--- a/plugins/flutter_aepmessaging/android/src/main/kotlin/com/adobe/marketing/mobile/flutter/flutter_aepmessaging/FlutterAEPMessagingPlugin.kt
+++ b/plugins/flutter_aepmessaging/android/src/main/kotlin/com/adobe/marketing/mobile/flutter/flutter_aepmessaging/FlutterAEPMessagingPlugin.kt
@@ -25,7 +25,7 @@ class FlutterAEPMessagingPlugin : FlutterPlugin, MethodCallHandler {
       // Messaging Methods
       "extensionVersion" -> result.success(Messaging.extensionVersion())
       "getCachedMessages" -> this.getCachedMessages(result)
-      "refreshInAppMessages" -> result.success(Messaging.refreshInAppMessages())
+      "refreshInAppMessages" -> this.refreshInAppMessages(result)
       // Message Methods
       "clearMessage" -> this.clearMessage(call, result)
       "dismissMessage" -> this.dismissMessage(call, result)
@@ -47,6 +47,11 @@ class FlutterAEPMessagingPlugin : FlutterPlugin, MethodCallHandler {
         message -> mapOf("id" to message.id, "autoTrack" to message.autoTrack)
     }.toList()
     result.success(cachedMessages)
+  }
+
+  private fun refreshInAppMessages(result: Result) {
+    Messaging.refreshInAppMessages()
+    result.success(null)
   }
 
   // Message Class Functions


### PR DESCRIPTION
## Description

  On Android, `refreshInAppMessages` was inlined in the method channel handler as:

  ```kotlin
  "refreshInAppMessages" -> result.success(Messaging.refreshInAppMessages())

  Since Messaging.refreshInAppMessages() returns void, Kotlin implicitly passes Unit into result.success(...) instead of null, causing a type mismatch on the Flutter/Dart method channel response.

  The fix extracts this into a dedicated private method that calls Messaging.refreshInAppMessages() first, then explicitly returns result.success(null) — consistent with all other void-returning methods in the
  plugin.

 Related Issue

  MOB-24978

  Motivation and Context

  Messaging.refreshInAppMessages() was not functioning correctly on Android due to the incorrect method channel result type being returned (Unit instead of null). The iOS implementation
  (SwiftFlutterAEPMessagingPlugin) already handles this correctly and this fix brings Android to parity.

  How Has This Been Tested?

  - Existing Dart unit tests verified — the refreshInAppMessages test confirms the correct method is invoked with null arguments
  - Manually called Messaging.refreshInAppMessages() from a Flutter app on an Android device and confirmed no type error is thrown on the method channel response

  Screenshots (if appropriate):

  N/A

  Types of changes

  [x] Bug fix (non-breaking change which fixes an issue)
  ```
  Checklist:

  [X] I have signed the Adobe Open Source CLA.
  [x] My code follows the code style of this project.
  [-] My change requires a change to the documentation.
  [-] I have updated the documentation accordingly.
  [x] I have read the CONTRIBUTING document.
  [-] I have added tests to cover my changes.
  [x] All new and existing tests passed.