### PR TITLE
Restore proposition retention in batch tracking methods

### DIFF
--- a/plugins/flutter_aepoptimize/ios/Classes/FlutterAEPOptimizePlugin.m
+++ b/plugins/flutter_aepoptimize/ios/Classes/FlutterAEPOptimizePlugin.m
@@ -192,9 +192,11 @@ governing permissions and limitations under the License.
 
 - (void)handleBatchDisplayed:(FlutterMethodCall *)call result:(FlutterResult)result {
     NSMutableArray<AEPOffer *> *offers = [NSMutableArray array];
+    NSMutableArray<AEPOptimizeProposition *> *propositions = [NSMutableArray array];
     for (NSDictionary *dict in call.arguments) {
         AEPOptimizeProposition *prop = [FlutterAEPOptimizeDataBridge propositionFromOfferTrackingDictionary:dict];
         if (prop && prop.offers.count > 0) {
+            [propositions addObject:prop];
             [offers addObject:prop.offers[0]];
         }
     }
@@ -206,9 +208,11 @@ governing permissions and limitations under the License.
 
 - (void)handleBatchGenerateDisplayInteractionXdm:(FlutterMethodCall *)call result:(FlutterResult)result {
     NSMutableArray<AEPOffer *> *offers = [NSMutableArray array];
+    NSMutableArray<AEPOptimizeProposition *> *propositions = [NSMutableArray array];
     for (NSDictionary *dict in call.arguments) {
         AEPOptimizeProposition *prop = [FlutterAEPOptimizeDataBridge propositionFromOfferTrackingDictionary:dict];
         if (prop && prop.offers.count > 0) {
+            [propositions addObject:prop];
             [offers addObject:prop.offers[0]];
         }
     }


### PR DESCRIPTION
The propositions array was inadvertently removed in acc612d while addressing code review comments. Without it, the loop-scoped proposition objects are deallocated before the SDK batch call, causing the weak Offer.proposition references to become nil and producing empty propositions in the Edge tracking payload.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
