### PR TITLE
Android - retain propositions in batch tracking methods to prevent empty payloads

### DIFF
--- a/plugins/flutter_aepoptimize/android/src/main/java/com/adobe/marketing/mobile/flutter/flutter_aepoptimize/FlutterAEPOptimizePlugin.java
+++ b/plugins/flutter_aepoptimize/android/src/main/java/com/adobe/marketing/mobile/flutter/flutter_aepoptimize/FlutterAEPOptimizePlugin.java
@@ -220,9 +220,13 @@ public class FlutterAEPOptimizePlugin implements FlutterPlugin, MethodCallHandle
     private void handleBatchDisplayed(MethodCall call, Result result) {
         List<Map<String, Object>> items = (List<Map<String, Object>>) call.arguments;
         List<Offer> offers = new ArrayList<>();
+        // Keep propositions alive — Offer uses a SoftReference to its proposition, which GC can
+        // clear once the loop-scoped `prop` goes out of scope, resulting in empty tracking payloads.
+        List<OptimizeProposition> propositions = new ArrayList<>();
         for (Map<String, Object> item : items) {
             OptimizeProposition prop = FlutterAEPOptimizeDataBridge.propositionFromOfferTrackingMap(item);
             if (prop != null && prop.getOffers() != null && !prop.getOffers().isEmpty()) {
+                propositions.add(prop);
                 offers.add(prop.getOffers().get(0));
             }
         }
@@ -236,9 +240,13 @@ public class FlutterAEPOptimizePlugin implements FlutterPlugin, MethodCallHandle
     private void handleBatchGenerateDisplayInteractionXdm(MethodCall call, Result result) {
         List<Map<String, Object>> items = (List<Map<String, Object>>) call.arguments;
         List<Offer> offers = new ArrayList<>();
+        // Keep propositions alive — Offer uses a SoftReference to its proposition, which GC can
+        // clear once the loop-scoped `prop` goes out of scope, resulting in empty tracking payloads.
+        List<OptimizeProposition> propositions = new ArrayList<>();
         for (Map<String, Object> item : items) {
             OptimizeProposition prop = FlutterAEPOptimizeDataBridge.propositionFromOfferTrackingMap(item);
             if (prop != null && prop.getOffers() != null && !prop.getOffers().isEmpty()) {
+                propositions.add(prop);
                 offers.add(prop.getOffers().get(0));
             }
         }

--- a/plugins/flutter_aepoptimize/ios/Classes/FlutterAEPOptimizePlugin.m
+++ b/plugins/flutter_aepoptimize/ios/Classes/FlutterAEPOptimizePlugin.m
@@ -192,6 +192,8 @@ governing permissions and limitations under the License.
 
 - (void)handleBatchDisplayed:(FlutterMethodCall *)call result:(FlutterResult)result {
     NSMutableArray<AEPOffer *> *offers = [NSMutableArray array];
+    // Keep propositions alive — Offer.proposition is weak and becomes nil once the loop-scoped
+    // `prop` goes out of scope, resulting in empty tracking payloads.
     NSMutableArray<AEPOptimizeProposition *> *propositions = [NSMutableArray array];
     for (NSDictionary *dict in call.arguments) {
         AEPOptimizeProposition *prop = [FlutterAEPOptimizeDataBridge propositionFromOfferTrackingDictionary:dict];
@@ -208,6 +210,8 @@ governing permissions and limitations under the License.
 
 - (void)handleBatchGenerateDisplayInteractionXdm:(FlutterMethodCall *)call result:(FlutterResult)result {
     NSMutableArray<AEPOffer *> *offers = [NSMutableArray array];
+    // Keep propositions alive — Offer.proposition is weak and becomes nil once the loop-scoped
+    // `prop` goes out of scope, resulting in empty tracking payloads.
     NSMutableArray<AEPOptimizeProposition *> *propositions = [NSMutableArray array];
     for (NSDictionary *dict in call.arguments) {
         AEPOptimizeProposition *prop = [FlutterAEPOptimizeDataBridge propositionFromOfferTrackingDictionary:dict];


### PR DESCRIPTION
Offer holds a SoftReference to its parent proposition on Android (weak on iOS). In batch methods, the loop-scoped variable is the only strong reference — once it goes out of scope, GC can clear the SoftReference, producing empty tracking payloads. Added the same retention pattern already applied on iOS, along with explanatory comments on both platforms.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
